### PR TITLE
remove unused `iosdriver` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "dependencies": {
         "ws": "0.4.x",
         "optimist": "0.3.x",
-        "colors": "0.6.x",
-        "iosdriver": "0.0.2"
+        "colors": "0.6.x"
     }
 }


### PR DESCRIPTION
`npm install` was failing because of `iosdriver` which is no longer used in this project. I was able to get this to work by removing that dependency.